### PR TITLE
Fix memory leak and update tests

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -279,6 +279,13 @@ class _TaskEditDialogContentState extends State<TaskEditDialogContent> {
   }
 
   @override
+  void dispose() {
+    _titleController.dispose();
+    _subTitleController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!; // ここで取得する
     return Padding(

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,11 +9,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:one_by_one/main.dart';
+import 'package:provider/provider.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => AppSettings(
+          locale: const Locale('en'),
+          seedColor: Colors.blue,
+          isDark: false,
+        ),
+        child: const OneByOneApp(),
+      ),
+    );
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- dispose text editing controllers to avoid leaks
- update widget tests to wrap app with provider

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465ffe64b0832382294fd2ff621663