### PR TITLE
Add reorderable grid with removable cards

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -136,43 +136,55 @@ class _HomeScreenState extends State<HomeScreen> {
               // ],
             ),
             const SizedBox(height: 16.0),
-            Expanded(
-              child: SingleChildScrollView(
-                child: ReorderableWrap(
-                  spacing: 10,
-                  runSpacing: 10,
-                  maxMainAxisCount: 3,
-                  needsLongPressDraggable: false,
-                  onReorder: (oldIndex, newIndex) {
-                    setState(() {
-                      final item = _items.removeAt(oldIndex);
-                      _items.insert(newIndex, item);
-                    });
-                  },
-                  children: [
-                    for (int i = 0; i < _items.length; i++)
-                      AspectRatio(
-                        key: ValueKey(_items[i]),
-                        aspectRatio: 1,
-                        child: CardWidget(
-                          title: 'Title',
-                          updatedText: _getUpdatedText(i),
-                          showCloseButton: true,
-                          onClose: () {
-                            setState(() {
-                              _items.removeAt(i);
-                            });
-                          },
-                        ),
+              Expanded(
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    const minTileWidth = 120.0;
+                    int columnCount = (constraints.maxWidth / minTileWidth).floor();
+                    if (columnCount < 3) {
+                      columnCount = 3;
+                    } else {
+                      columnCount -= columnCount % 3;
+                      if (columnCount == 0) columnCount = 3;
+                    }
+                    return SingleChildScrollView(
+                      child: ReorderableWrap(
+                        spacing: 10,
+                        runSpacing: 10,
+                        maxMainAxisCount: columnCount,
+                        needsLongPressDraggable: false,
+                        onReorder: (oldIndex, newIndex) {
+                          setState(() {
+                            final item = _items.removeAt(oldIndex);
+                            _items.insert(newIndex, item);
+                          });
+                        },
+                        children: [
+                          for (int i = 0; i < _items.length; i++)
+                            AspectRatio(
+                              key: ValueKey(_items[i]),
+                              aspectRatio: 1,
+                              child: CardWidget(
+                                title: 'Title',
+                                updatedText: _getUpdatedText(i),
+                                showCloseButton: true,
+                                onClose: () {
+                                  setState(() {
+                                    _items.removeAt(i);
+                                  });
+                                },
+                              ),
+                            ),
+                          const AspectRatio(
+                            aspectRatio: 1,
+                            child: AddCardWidget(),
+                          ),
+                        ],
                       ),
-                    const AspectRatio(
-                      aspectRatio: 1,
-                      child: AddCardWidget(),
-                    ),
-                  ],
+                    );
+                  },
                 ),
               ),
-            ),
           ],
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     sdk: flutter
   intl: ^0.20.2
   provider: ^6.1.5
+  reorderables: ^0.4.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `reorderables` package to handle drag and drop
- make HomeScreen card grid reorderable
- show X button that removes a card
- maintain square card layout

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad95a32cc832390e8cf84fb2189ae